### PR TITLE
Change cartActions:addToCart to use product SKU, as required by API

### DIFF
--- a/src/redux/actions/cartActions.js
+++ b/src/redux/actions/cartActions.js
@@ -21,11 +21,11 @@ export const addToCart = (item, addToast, cartId, quantityCount, defaultStore, u
       let param;
       let response;
       let message;
-      console.log('Item ' + cartId + " quantity " + quantityCount);
+      console.log('Item ' + item.sku + " quantity " + quantityCount);
       if (selectedProductOptions !== undefined) {
-        param = { "attributes": selectedProductOptions, "product": item.id, "quantity": quantityCount }
+        param = { "attributes": selectedProductOptions, "product": item.sku, "quantity": quantityCount }
       } else {
-        param = { "product": item.id, "quantity": quantityCount }
+        param = { "product": item.sku, "quantity": quantityCount }
       }
       console.log('Cart parameters ' + JSON.stringify(param));
       if (cartId) {


### PR DESCRIPTION
Clicking add to cart fails on the latest revision from main.
The API for addToCart expects SKU, though the react app is sending ID.

This change sends the required value for the addToCart api